### PR TITLE
Use a single commit on the deploy branch

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -43,3 +43,4 @@ jobs:
                 ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 BRANCH: deploy
                 FOLDER: output
+                SINGLE_COMMIT: true


### PR DESCRIPTION
Rather than maintaining full history.

This is an attempt to cut down the deploy time on Netlify, which is steadily
increasing.